### PR TITLE
Allow to skip node module folder testing

### DIFF
--- a/node/npm.sls
+++ b/node/npm.sls
@@ -4,7 +4,9 @@ npm_install_{{ install_dir }}:
   cmd.run:
     - name: 'npm install'
     - cwd: {{ install_dir }}
+    {%- if test_node_modules is defined and test_node_modules == true %}
     - unless: test -d {{ install_dir }}/node_modules
+    {%- endif %}
     {%- if install_user is defined %}
     - user: {{ install_user }}
     {%- endif %}

--- a/pillar.example
+++ b/pillar.example
@@ -2,6 +2,8 @@
 node:
   version: '0.10.35' # version if you do not want 'latest'
   npm:
+    # Don't run npm install if the node_modules folder exists
+    test_node_modules: true
     # Install the non-global packages as this user
     install_user: vagrant
     # A list of directories to run "npm install" in.

--- a/pillar.example
+++ b/pillar.example
@@ -2,7 +2,7 @@
 node:
   version: '0.10.35' # version if you do not want 'latest'
   npm:
-    # Don't run npm install if the node_modules folder exists
+    # Run npm install if the node_modules folder exists
     test_node_modules: true
     # Install the non-global packages as this user
     install_user: vagrant


### PR DESCRIPTION
As it might not be wishful for certain situations where you'd like to force a new install in already existing folders.