### PR TITLE
Use better test for existance of `n`

### DIFF
--- a/node/install.sls
+++ b/node/install.sls
@@ -8,7 +8,7 @@ nodejs:
 install_node_n:
   cmd.run:
     - name: npm install -g n
-    - unless: test -f /usr/lib/node_modules/n/bin/n
+    - unless: hash n 2>/dev/null
     - require:
       - pkg: nodejs
 


### PR DESCRIPTION
### Context
Depending on which version of npm is the current one, the location of globally installed npm-modules may vary. Therefore it is preferable to test for the availability of `n` by checking for the availability of a command named `n` over the test for the exact location of the `n` executable on the filesystem

### What has been done
- Changed the check for the existance of `n`
