### PR TITLE
Retrieve GPG key from the Ubuntu Keyserver

### DIFF
--- a/node/repo.sls
+++ b/node/repo.sls
@@ -6,9 +6,10 @@
 nodejs_repo:
   pkgrepo.managed:
     - humanname: Node.js Repo
-    - key_url: https://deb.nodesource.com/gpgkey/nodesource.gpg.key
     - name: deb https://deb.nodesource.com/node {{ lsb_codename }} main
     - dist: {{ lsb_codename }}
+    - keyid: '68576280'
+    - keyserver: keyserver.ubuntu.com
     - file: /etc/apt/sources.list.d/nodesource.list
     - refresh: True
     - require_in:


### PR DESCRIPTION
Salt has trouble adding this repo key, because it uses the root domain to verify stuff on (e.g. ssl certificate) but since it redirects to Github.com this causes issues.
Switching to using the Keyserver-key should resolve this issue.