### PR TITLE
Support repo's beyond node4

### DIFF
--- a/node/repo.sls
+++ b/node/repo.sls
@@ -1,12 +1,13 @@
 {%- set lsb_codename = salt['grains.get']('lsb_distrib_codename') %}
 {%- set os = salt['grains.get']('os') %}
 {%- set os_family = salt['grains.get']('os_family') %}
+{%- set repo = salt['pillar.get']('node:repo', 'node') %}
 
 # Install Node repository
 nodejs_repo:
   pkgrepo.managed:
     - humanname: Node.js Repo
-    - name: deb https://deb.nodesource.com/node {{ lsb_codename }} main
+    - name: deb https://deb.nodesource.com/{{ repo }} {{ lsb_codename }} main
     - dist: {{ lsb_codename }}
     - keyid: '68576280'
     - keyserver: keyserver.ubuntu.com

--- a/pillar.example
+++ b/pillar.example
@@ -1,7 +1,7 @@
 # Example settings for node.
 node:
-  repo: 'node_7.x'
-  version: '7.7.4' # version if you do not want 'latest'
+  repo: 'node_6.x'
+  #version: '6.10.1' # version if you do not want 'latest'
 
   #npm:
   #  # Install the non-global packages as this user

--- a/pillar.example
+++ b/pillar.example
@@ -1,6 +1,8 @@
 # Example settings for node.
 node:
-  version: '0.10.35' # version if you do not want 'latest'
+  repo: 'node_7.x'
+  version: '7.7.4' # version if you do not want 'latest'
+
   #npm:
   #  # Install the non-global packages as this user
   #  install_user: vagrant


### PR DESCRIPTION
Their repo structure is very impractical. 
The `node` repo only has very old versions, yet for every major version they create a new repo. This PR allows you to specify which repo to use.